### PR TITLE
add policy for cost explorer and budgets access

### DIFF
--- a/modules/account-sso/README.md
+++ b/modules/account-sso/README.md
@@ -22,6 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.bcgov_cost_explorer_and_budgets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.bcgov_perm_boundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_saml_provider.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_saml_provider) | resource |

--- a/modules/account-sso/main.tf
+++ b/modules/account-sso/main.tf
@@ -39,6 +39,10 @@ resource "aws_iam_role" "role" {
   ]
 }
 EOF
+
+  depends_on = [
+    aws_iam_policy.bcgov_cost_explorer_and_budgets,
+  ]
 }
 
 resource "aws_iam_policy" "bcgov_perm_boundary" {
@@ -149,6 +153,28 @@ resource "aws_iam_policy" "bcgov_perm_boundary" {
         Effect   = "Deny"
         Resource = "arn:aws:secretsmanager:*:*:secret:accelerator*"
         Sid      = "DenyDefaultSecretManagerAlteration"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "bcgov_cost_explorer_and_budgets" {
+  name        = "BCGOV_CostExplorerAndBudgets"
+  description = "Give all access to Cost Explorer and Budgets"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowCostExplorer"
+        Effect   = "Allow"
+        Action   = "ce:*"
+        Resource = "*"
+      },
+      {
+        Sid      = "AllowBudgets"
+        Effect   = "Allow"
+        Action   = "budgets:*"
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
Related to: bcgov/cloud-pathfinder#2705

Adds a policy that gives full access to cost explorer and budgets that is used with the billing role